### PR TITLE
fix: sparkline should be relative to values instead of zero; zero dividend/divisior issue; sub-pixel issue.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -26,12 +26,12 @@ const getD: DGetter = (
   const maxX: number = values.length - 1;
   const minY: number = Math.min(...values);
   const maxY: number = Math.max(...values);
-  const diffY: number = maxY - minY;
+  const diffMinMaxY: number = maxY - minY;
   for (let i: number = 0; i <= maxX; i++) {
     l.push(
       round(i / maxX * viewBoxWidth, decimals) + ',' +
       round(
-        viewBoxHeight - ((values[i] - minY) / diffY) * viewBoxHeight,
+        viewBoxHeight - ((values[i] - minY) / diffMinMaxY) * viewBoxHeight,
         decimals
       )
     );

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,11 +24,15 @@ const getD: DGetter = (
 ): string => {
   let l: string[] = [];
   const maxX: number = values.length - 1;
+  const minY: number = Math.min(...values);
   const maxY: number = Math.max(...values);
   for (let i: number = 0; i <= maxX; i++) {
     l.push(
       round(i / maxX * viewBoxWidth, decimals) + ',' +
-      round(viewBoxHeight - (values[i] / maxY * viewBoxHeight), decimals),
+      round(
+        viewBoxHeight - ((values[i] - minY) / (maxY - minY)) * viewBoxHeight,
+        decimals
+      )
     );
   }
   return `M ${l.join(' L ')}`;

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,13 +28,18 @@ const getD: DGetter = (
   const maxY: number = Math.max(...values);
   const diffMinMaxY: number = maxY - minY;
   for (let i: number = 0; i <= maxX; i++) {
-    l.push(
-      round(i / maxX * viewBoxWidth, decimals) + ',' +
-      round(
-        viewBoxHeight - ((values[i] - minY) / diffMinMaxY) * viewBoxHeight,
+    const diffY = values[i] - minY
+    const partA = round(i / maxX * viewBoxWidth, decimals)
+    let partB
+    if (diffY && diffMinMaxY) {
+      partB = round(
+        viewBoxHeight - (diffY / diffMinMaxY) * viewBoxHeight,
         decimals
       )
-    );
+    } else {
+      partB = 0
+    }
+    l.push(partA + ',' + partB);
   }
   return `M ${l.join(' L ')}`;
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,8 @@ const getD: DGetter = (
     const diffY = values[i] - minY
     const partA = round(i / maxX * viewBoxWidth, decimals)
     let partB
-    if (diffY && diffMinMaxY) {
+    /* if the sparkline is a flat line */
+    if (diffMinMaxY) {
       partB = round(
         viewBoxHeight - (diffY / diffMinMaxY) * viewBoxHeight,
         decimals

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,11 +26,12 @@ const getD: DGetter = (
   const maxX: number = values.length - 1;
   const minY: number = Math.min(...values);
   const maxY: number = Math.max(...values);
+  const diffY: number = maxY - minY;
   for (let i: number = 0; i <= maxX; i++) {
     l.push(
       round(i / maxX * viewBoxWidth, decimals) + ',' +
       round(
-        viewBoxHeight - ((values[i] - minY) / (maxY - minY)) * viewBoxHeight,
+        viewBoxHeight - ((values[i] - minY) / diffY) * viewBoxHeight,
         decimals
       )
     );

--- a/src/index.ts
+++ b/src/index.ts
@@ -103,6 +103,7 @@ export default class Sparkline {
           fill="transparent"
           stroke="${this._stroke}"
           stroke-width="${this._strokeWidth}"
+          transform="translate(0.5,0.5)"
         />
       `;
 


### PR DESCRIPTION
The code was considering 0 to be the base value for Y axis so the sparkline currently does not show relative movements in values clearly.

For example, the sparkline for `[110, 120, 130, 110, 120, 130]` would appear flatter than `[10, 20, 30, 10, 20, 30]` even though the relative differences between the numbers is the same. As the numbers go higher (1000s), the line visually appears to be a straight line.

Please see the screenshot below for reference.
https://i.imgur.com/HMyqPU9.png

Sandbox with the change: https://codesandbox.io/p/sandbox/pedantic-hawking-hzwsgl?file=%2Fsrc%2Flib%2Fsparkline-svg.ts%3A29%2C9-32%2C10